### PR TITLE
Add tuple roles and dots claim matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,58 +47,88 @@ The format of the file is the following:
 {
     "defaults": ...
     "mappings": {
-        "groupname_1": Array of Arrays,
-        "groupname_2": Array of Arrays,
-        "groupname_3": Array of Arrays,
-        ...
+        "roles": {
+            "groupname_1": Array of Arrays,
+            "groupname_2": Array of Arrays,
+            "groupname_3": Array of Arrays,
+            ...
+        },
+        "dots": {
+            "groupname_4": Array of Strings,
+            ...
+        }
     }
 }
 ```
-Any element of an array `groupname` is a couple `[oidcRole, oidcGroup]` (as returned by the datatracker OIDC user-info API) that will match the `groupname` wiki.js group, e.g.:
+Any element of an array `groupname` in the `roles` section is a tuple `[oidcRole, oidcGroup, ... ]` (as returned by the datatracker OIDC user-info API) that will match the `groupname` wiki.js group, e.g.:
 ```
 ...
 "mappings": {
-    "admins": [
-        [
-            "ad",
-            "iesg"
+    "roles": {
+        "admins": [
+            [
+                "ad",
+                "iesg",
+                ...
+            ],
+            [
+                "chair",
+                "ietf",
+                ...
+            ],
         ],
-        [
-            "chair",
-            "ietf"
+        "iesg": [
+            [
+                "ad",
+                "iesg"m
+                ...
+            ],
+            [
+                "execdir",
+                "ietf",
+                ...
+            ]
         ],
-    ],
-    "iesg": [
-        [
-            "ad",
-            "iesg"
-        ],
-        [
-            "execdir",
-            "ietf"
-        ]
-    ],
+        ...
+    }
     ...
 }
 ```
-By using wildcards `*` you can omit an `oidcRole`, an `oidcGroup` or both, e.g.:
+By using wildcards `*` you can omit any tuple element, e.g.:
 ```
 "mappings": {
-    "chairs": [
-        [
-            "chair",
-            "*"
-        ]
-    ],
-    "iesg-users": [
-        [
-            "*",
-            "iesg"
-        ]
-    ],
+    "roles": {
+        "chairs": [
+            [
+                "chair",
+                "*",
+                ...
+            ]
+        ],
+        "iesg-users": [
+            [
+                "*",
+                "iesg",
+                ...
+            ]
+        ],
+        ...
+    }
     ...
 }
 ```
+Any element of an array `groupname` in the mappings `dots` section is an array of strings `[dot1, dot2, ... ]` (as returned by the datatracker OIDC user-info API) that will match the `groupname` wiki.js group, e.g.:
+```
+"mappings": {
+    ...
+    "dots": {
+        "chairs": [ "llc", ... ],
+        ...
+    }
+    ...
+}
+```
+
 Any change to the mappings file *should* be detected (checking the last-modified timestamp) when the next authentication request comes in.
 
 To manually reload the configuration head to the *Authentication* strategy configuration on the wiki.js web-gui and hit *Apply*.

--- a/ietf/definition.yml
+++ b/ietf/definition.yml
@@ -52,7 +52,7 @@ props:
     type: String
     title: 'Scopes'
     hint: 'User scopes to request'
-    default: 'openid profile email photo roles'
+    default: 'openid profile email photo roles dots'
     order: 8
   emailClaim:
     type: String
@@ -67,3 +67,9 @@ props:
     hint: 'Field containing the roles array'
     default: 'roles'
     order: 10
+  dotsClaim:
+    type: String
+    title: 'Dots Claim'
+    hint: 'Field containing the dots array'
+    default: 'dots'
+    order: 11

--- a/ietf/mappings.json
+++ b/ietf/mappings.json
@@ -3,58 +3,68 @@
         "members"
     ],
     "mappings": {
-        "admins": [
-            [
-                "ad",
-                "iesg"
-            ]
-        ],
-        "editors": [
-            [
-                "chair",
-                "*"
+        "roles": {
+            "admins": [
+                [
+                    "ad",
+                    "iesg"
+                ]
             ],
-            [
-                "ad",
-                "iesg"
-            ]
-        ],
-        "iesg": [
-            [
-                "ad",
-                "iesg"
+            "editors": [
+                [
+                    "chair",
+                    "*"
+                ],
+                [
+                    "ad",
+                    "iesg"
+                ]
             ],
-            [
-                "execdir",
-                "ietf"
-            ]
-        ],
-        "ietf-chairs": [
-            [
-                "chair",
-                "ietf"
-            ]
-        ],
-        "nomcom2021": [
-            [
-                "chair",
-                "nomcom2021"
+            "iesg": [
+                [
+                    "ad",
+                    "iesg"
+                ],
+                [
+                    "execdir",
+                    "ietf"
+                ]
             ],
-            [
-                "member",
-                "nomcom2021"
+            "ietf-chairs": [
+                [
+                    "chair",
+                    "ietf"
+                ]
             ],
-            [
-                "liaison",
-                "nomcom2021"
+            "nomcom2021": [
+                [
+                    "chair",
+                    "nomcom2021"
+                ],
+                [
+                    "member",
+                    "nomcom2021"
+                ],
+                [
+                    "liaison",
+                    "nomcom2021"
+                ]
+            ],
+            "nomcom2021-chairs": [
+                [
+                    "chair",
+                    "nomcom2021"
+                ]
+            ],
+            "owners": []
+        },
+        "dots": {
+            "editors": [
+                "ad"
+            ],
+            "ietf-chairs": [
+                "chair"
             ]
-        ],
-        "nomcom2021-chairs": [
-            [
-                "chair",
-                "nomcom2021"
-            ]
-        ],
-        "owners": []
+        }
     }
 }

--- a/test/files/mappings.json
+++ b/test/files/mappings.json
@@ -4,40 +4,52 @@
         "users_gid2"
     ],
     "mappings": {
-        "everyone_gid3": [
-            [
-                "*",
-                "*"
-            ]
-        ],
-        "chairs_gid4": [
-            [
-                "chair",
-                "*"
-            ]
-        ],
-        "ietf_gid5": [
-            [
-                "*",
-                "ietf"
-            ]
-        ],
-        "ietf-chairs_gid6": [
-            [
-                "chair",
-                "ietf"
-            ]
-        ],
-        "void_gid98": [],
-        "generic_gid99": [
-            [
-                "role1",
-                "group1"
+        "roles": {
+            "everyone_gid3": [
+                [
+                    "*",
+                    "*"
+                ]
             ],
-            [
-                "role2",
-                "group2"
+            "chairs_gid4": [
+                [
+                    "chair",
+                    "*"
+                ]
+            ],
+            "ietf_gid5": [
+                [
+                    "*",
+                    "ietf"
+                ]
+            ],
+            "ietf-chairs_gid6": [
+                [
+                    "chair",
+                    "ietf"
+                ]
+            ],
+            "void_gid98": [],
+            "generic_gid99": [
+                [
+                    "role1",
+                    "group1"
+                ],
+                [
+                    "role2",
+                    "group2"
+                ]
             ]
-        ]
+        },
+        "dots": {
+            "chairs_gid1001": [
+                "chair"
+            ],
+            "void_gid1098": [],
+            "generic_gid1099": [
+                "dot1",
+                "dot2"
+            ]
+        }
     }
 }

--- a/test/files/profile-generic.json
+++ b/test/files/profile-generic.json
@@ -12,9 +12,12 @@
                 "group2"
             ]
         ],
+        "dots": [
+            "dot2"
+        ],
         "sub": "1234"
     },
-    "_raw": "{\"sub\": \"1575\", \"name\": \"John Doe\", \"given_name\": \"John\", \"family_name\": \"Doe\", \"nickname\": \"-\", \"picture\": \"https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg\", \"email\": \"john@doe.org\", \"roles\": [[\"role2\", \"group2\"]]}",
+    "_raw": "{\"sub\": \"1575\", \"name\": \"John Doe\", \"given_name\": \"John\", \"family_name\": \"Doe\", \"nickname\": \"-\", \"picture\": \"https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg\", \"email\": \"john@doe.org\", \"roles\": [[\"role2\", \"group2\"]], \"dots\": [\"dot2\"]}",
     "displayName": "John Doe",
     "id": "1234",
     "name": {

--- a/test/files/profile-ietf-chair.json
+++ b/test/files/profile-ietf-chair.json
@@ -12,9 +12,10 @@
                 "ietf"
             ]
         ],
+        "dots": [],
         "sub": "1234"
     },
-    "_raw": "{\"sub\": \"1575\", \"name\": \"John Doe\", \"given_name\": \"John\", \"family_name\": \"Doe\", \"nickname\": \"-\", \"picture\": \"https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg\", \"email\": \"john@doe.org\", \"roles\": [[\"chair\", \"ietf\"]]}",
+    "_raw": "{\"sub\": \"1575\", \"name\": \"John Doe\", \"given_name\": \"John\", \"family_name\": \"Doe\", \"nickname\": \"-\", \"picture\": \"https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg\", \"email\": \"john@doe.org\", \"roles\": [[\"chair\", \"ietf\"]], \"dots\": []}",
     "displayName": "John Doe",
     "id": "1234",
     "name": {

--- a/test/files/profile-no-roles.json
+++ b/test/files/profile-no-roles.json
@@ -7,9 +7,10 @@
         "nickname": "-",
         "picture": "https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg",
         "roles": [],
+        "dots": [],
         "sub": "1234"
     },
-    "_raw": "{\"sub\": \"1575\", \"name\": \"John Doe\", \"given_name\": \"John\", \"family_name\": \"Doe\", \"nickname\": \"-\", \"picture\": \"https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg\", \"email\": \"john@doe.org\", \"roles\": []}",
+    "_raw": "{\"sub\": \"1575\", \"name\": \"John Doe\", \"given_name\": \"John\", \"family_name\": \"Doe\", \"nickname\": \"-\", \"picture\": \"https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/John_Doe_001_oifyeNP.jpg\", \"email\": \"john@doe.org\", \"roles\": [], \"dots\": []}",
     "displayName": "John Doe",
     "id": "1234",
     "name": {

--- a/test/ietf-oidc.test.js
+++ b/test/ietf-oidc.test.js
@@ -35,7 +35,10 @@ describe('JSON importing Test', () => {
   const context = {
     groupMappings: {
       defaults: [],
-      mappings: {},
+      mappings: {
+        roles: {},
+        dots: {},
+      },
     },
     lastModified: -1,
   };
@@ -47,8 +50,11 @@ describe('JSON importing Test', () => {
   it('context should contain defaults', () => {
     expect(_.isEqual(context.groupMappings.defaults, jsonObj.defaults)).to.be.true;
   });
-  it('context should contain mappings', () => {
-    expect(_.isEqual(context.groupMappings.mappings, jsonObj.mappings)).to.be.true;
+  it('context should contain roles mappings', () => {
+    expect(_.isEqual(context.groupMappings.mappings.roles, jsonObj.mappings.roles)).to.be.true;
+  });
+  it('context should contain dots mappings', () => {
+    expect(_.isEqual(context.groupMappings.mappings.dots, jsonObj.mappings.dots)).to.be.true;
   });
   it('context last-modified should be greater than 0', () => {
     expect(context.lastModified).to.be.above(0);
@@ -60,7 +66,10 @@ describe('User role matching Test', () => {
   const context = {
     groupMappings: {
       defaults: [],
-      mappings: {},
+      mappings: {
+        roles: {},
+        dots: {},
+      },
     },
     lastModified: -1,
   };
@@ -69,16 +78,16 @@ describe('User role matching Test', () => {
   const ietfChairProfile = JSON.parse(readFileSync(join(__dirname, 'files/profile-ietf-chair.json')));
   const genericProfile = JSON.parse(readFileSync(join(__dirname, 'files/profile-generic.json')));
 
-  it('User without roles should have only default groups', async () => {
-    const matchedGroups = await authModule.matchUserRoles({ context, profile: noRolesProfile, rolesClaim: 'roles' });
+  it('User without roles and dots should have only default groups', async () => {
+    const matchedGroups = await authModule.matchUserRoles({ context, profile: noRolesProfile, rolesClaim: 'roles', dotsClaim: 'dots' });
     expect(_.isEqual(matchedGroups, [1, 2])).to.be.true;
   });
   it('User with roles matching the wildcards', async () => {
-    const matchedGroups = await authModule.matchUserRoles({ context, profile: ietfChairProfile, rolesClaim: 'roles' });
+    const matchedGroups = await authModule.matchUserRoles({ context, profile: ietfChairProfile, rolesClaim: 'roles', dotsClaim: 'dots' });
     expect(_.isEqual(matchedGroups, [1, 2, 3, 4, 5, 6])).to.be.true;
   });
-  it('User with roles matching generic rules', async () => {
-    const matchedGroups = await authModule.matchUserRoles({ context, profile: genericProfile, rolesClaim: 'roles' });
-    expect(_.isEqual(matchedGroups, [1, 2, 3, 99])).to.be.true;
+  it('User with roles and dots matching generic rules', async () => {
+    const matchedGroups = await authModule.matchUserRoles({ context, profile: genericProfile, rolesClaim: 'roles', dotsClaim: 'dots' });
+    expect(_.isEqual(matchedGroups, [1, 2, 3, 99, 1099])).to.be.true;
   });
 });


### PR DESCRIPTION
This PR adds to the authentication module the support for `dots` claim and **tuple roles** matching.

## Dots claim matching

If requested by the client, the datatracker user-info API now returns the `dots` property in the user profile:
```json
{
        "dots": [
            "ad",
            "llc"
        ],
        "email": "john@doe.net",
        "family_name": "Doe",
        "given_name": "John",
        "name": "John Doe",
        "nickname": "-",
        "picture": "https://www.ietf.org/cdn-cgi/image/fit=scale-down,width=80,height=80/media/photo/john-doe.jpg",
        "roles": [
            [
                "ad",
                "ops"
            ],
            [
                "ad",
                "dnsop"
            ],
            [
                "ad",
                "v6ops"
            ]
        ],
        "sub": "499"
}
```
`dots` claim  can be used now to match a wikijs group.

As such the `mappings.json` format has been changed to support the new feature:

```json
{
    "defaults": [
        "members"
    ],
    "mappings": {
        "roles": {
            "admins": [
                [
                    "ad",
                    "iesg"
                ]
            ],
            "editors": [
                [
                    "chair",
                    "*"
                ]
            ]
        },
        "dots": {
            "editors": [
                "ad"
            ],
            "ietf-chairs": [
                "llc"
            ]
        }
    }
}
```
Wildcards are not supported in the `dots` matching rules.


## Tuple Roles matching

The roles in the `mappings.json` can now be arrays of unspecified size.

```json
{
    "defaults": [
        "members"
    ],
    "mappings": {
        "roles": {
            "admins": [
                [
                    "ad",
                    "iesg",
                    "test",
                    "test2"
                ]
            ],
            "editors": [
                [
                    "chair",
                    "*"
                    "test",
                    "*"
                ]
            ]
        },
        "dots": {
            "editors": [
                "ad"
            ],
            "ietf-chairs": [
                "llc"
            ]
        }
    }
}
```
A rule is matched only if the array of the rule has the same length of the array in the user claim. 