### PR TITLE
fix: Correct a typo in the GO template language

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               value: {{ default "1" .Values.postgres.NODE_TLS_REJECT_UNAUTHORIZED | quote }}
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
-            {{- if Values.env }}
+            {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
             {{- end }}
     {{- with .Values.volumeMounts }}


### PR DESCRIPTION
Refer to values file map correctly as '.Values' instead of as 'Values', which would be a function.